### PR TITLE
Update 04.md

### DIFF
--- a/content/a/04.md
+++ b/content/a/04.md
@@ -103,7 +103,7 @@ Create an endpoint `/app/error` that returns an error in the response.
 
 The error should read "Error test successful."
 
->HINT: This should *just work* if you model your endpoint on the first example in the error documentation from Express: http://expressjs.com/en/guide/error-handling.html#the-default-error-handler
+>HINT: This should *just work* if you model your endpoint on the first example in the error documentation from Express: http://expressjs.com/en/guide/error-handling.html
 
 ### Create an access log file
 


### PR DESCRIPTION
Hi! I'm not sure if this was intended, but under app/error, the original write-up links to halfway through the error documentation from Express instead of the top of the page, where the first example is, so I proposed an edit to the URL. Thanks!