### PR TITLE
fix link in md to a05 issues page

### DIFF
--- a/content/a/05.md
+++ b/content/a/05.md
@@ -197,4 +197,4 @@ You also already have most of the code needed to do this.
 You don't need luck.
 
 And, if you need help, we are always here.
-Just (create an issue on the main a05 repo page)[https://github.com/comp426-2022-spring/a05/issues].
+Just [create an issue on the main a05 repo page](https://github.com/comp426-2022-spring/a05/issues).


### PR DESCRIPTION
I think that [] and () appeared to be accidentally switched around for the link at the very end, so this is a proposed change to fix it!